### PR TITLE
fix：删除拍照保存到相册逻辑和iOS效果保持一致

### DIFF
--- a/harmony/src/main/ets/service/CameraService.ts
+++ b/harmony/src/main/ets/service/CameraService.ts
@@ -117,7 +117,7 @@ class CameraService {
         return;
       }
       this.previewProfileObj = previewProfile;
-      console.log('previewProfile:::',JSON.stringify(previewProfile))
+      console.log('previewProfile:::', JSON.stringify(previewProfile))
       // 创建previewOutput输出对象
       this.previewOutput = this.createPreviewOutputFn(this.cameraManager, this.previewProfileObj, surfaceId);
       if (this.previewOutput === undefined) {
@@ -611,8 +611,9 @@ class CameraService {
     }
     fs.closeSync(file);
     this.photoAsset.uri = photoFile;
-    this.photoAsset.name= photoAccess.get('display_name') as string;
+    this.photoAsset.name = photoAccess.get('display_name') as string;
   }
+
   /**
    * 监听拍照事件
    */
@@ -642,7 +643,11 @@ class CameraService {
           Logger.error(TAG, 'photoAsset is undefined');
           return;
         }
-        this.savePicture(photoAsset);
+        const uri = photoAsset.get('uri') as string;
+        const name = photoAsset.get('display_name') as string;
+        this.photoAsset.uri = uri;
+        this.photoAsset.name = name;
+        // this.savePicture(photoAsset);
       });
     } catch (err) {
       Logger.error(TAG, 'photoOutputCallBack error');


### PR DESCRIPTION

# Summary


- 删除拍照时多了保存到相册逻辑和iOS效果保持一致？


## Test Plan


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [x] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

