### PR TITLE
fix：修复：805环境使用capture功能没有返回photo路径 #28

### DIFF
--- a/harmony/camera_kit/src/main/ets/service/CameraService.ts
+++ b/harmony/camera_kit/src/main/ets/service/CameraService.ts
@@ -73,6 +73,23 @@ class CameraService {
   constructor() {
     this.phAccessHelper = photoAccessHelper.getPhotoAccessHelper(this.context);
     this.basicPath = this.context.filesDir;
+    for (let outPath of this.outPathArray) {
+      this.initTempPath(outPath);
+    }
+  }
+
+  initTempPath(path: string) {
+    let pathDir = this.basicPath + '/' + path;
+    let res;
+    try {
+      res = fs.accessSync(pathDir);
+    } catch (error) {
+      Logger.error(TAG, `constructor error path not exists:${JSON.stringify(error)}`);
+    }
+    if (!res) {
+      Logger.error(TAG, `constructor photo path not exists:${pathDir}`);
+      fs.mkdirSync(pathDir, true);
+    }
   }
 
   /**


### PR DESCRIPTION


# Summary

Closes https://github.com/react-native-oh-library/react-native-camera-kit/issues/28

- fix：修复：805环境使用capture功能没有返回photo路径 #28


## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)


