### PR TITLE
fix:修复进入扫码页面强制释放相机流导致抛出异常的问题

### DIFF
--- a/harmony/camera_kit/src/main/ets/RTNCameraKit.ets
+++ b/harmony/camera_kit/src/main/ets/RTNCameraKit.ets
@@ -318,8 +318,11 @@ export struct RTNCameraKitView {
   }
 
   handleRelease() {
-    CameraService.releaseCamera();
-    ScanService.scanRelease();
+    if (this.isScan) {
+      ScanService.scanRelease();
+    } else {
+      CameraService.releaseCamera();
+    }
     this.clearTimer();
     this.isScanned = false;
     this.tipShow = false;

--- a/harmony/camera_kit/src/main/ets/service/ScanService.ts
+++ b/harmony/camera_kit/src/main/ets/service/ScanService.ts
@@ -28,6 +28,7 @@ class ScanService {
   private zoomMode: ZoomMode = 'on';
   public isScanLine: boolean = false;
   public isStopCamera: boolean = false;
+  public isReleaseCamera: boolean = true;
   private initSuccess: boolean = false;
 
   constructor() {
@@ -101,6 +102,7 @@ class ScanService {
     callback: AsyncCallback<Array<scanBarcode.ScanResult>>): void {
     try {
       this.isStopCamera = false;
+      this.isReleaseCamera = false;
       customScan.start(viewControl, callback);
     } catch (error) {
       Logger.error(TAG, `Failed to start customScan. Code: ${error.code}`);
@@ -230,8 +232,12 @@ class ScanService {
    * 页面消失或隐藏时，释放相机流
    */
   async scanRelease() {
+    if (this.isReleaseCamera) {
+      return;
+    }
     this.scanStop();
     this.initSuccess = false;
+    this.isReleaseCamera = true;
     try {
       customScan.release().then(() => {
       }).catch((error: BusinessError) => {


### PR DESCRIPTION
<!-- 感谢您提交PR！请按照模板填写，以便审阅者可以轻松理解和评估代码变更的影响。Thanks for submitting a pull request! -->

# Summary

请解释此次更改的 **动机**，以下是一些帮助您的要点：

- 这个 PR 解决了哪些 issues？请标记这些 issues，以便合并 PR 后这些 issues 将会被自动关闭。
- 修复了进入扫码页面强制释放相机流导致抛出异常问题
- 这个功能是什么？（如果适用）
- 扫一扫功能
- 您是如何实现解决方案的？
- 在进行释放相机流之前，添加一个变量用于判断是否释放相机流，如果为true则返回，否则则进行
- 这个更改影响了库的哪些部分？
- 扫码服务

## Test Plan

展示代码的稳定性。例如：用来复现场景的命令输入和结果输出、测试用例的路径地址，或者附上截图和视频。
## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [x] 已经在真机设备或模拟器上测试通过
- [x] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [x] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

