### PR TITLE
fix:修复锁定模式没有显示黄色焦点框以及添加支持模拟onError回调

### DIFF
--- a/harmony/camera_kit/src/main/ets/RTNCameraKit.ets
+++ b/harmony/camera_kit/src/main/ets/RTNCameraKit.ets
@@ -5,7 +5,7 @@
  */
 
 import { RNComponentContext, RNViewBase } from '@rnoh/react-native-openharmony';
-import { BoxSizes, RTNCamerakitViewSpec } from './types';
+import { BoxSizes, FocusMode, RTNCamerakitViewSpec } from './types';
 import { abilityAccessCtrl, common } from '@kit.AbilityKit';
 import Logger from './utils/Logger';
 import { display } from '@kit.ArkUI';
@@ -78,6 +78,7 @@ export struct RTNCameraKitView {
   @State tipShow: boolean = false;
   @State isInitSuccess: boolean = false;
   @State currentProps: CameraProps = {};
+  @State isMockOnError: boolean = false;
   @State viewSize: BoxSizes = {
     centerSize: {
       width: 0,
@@ -257,6 +258,9 @@ export struct RTNCameraKitView {
           if (command === Constants.CHECK_DEVICE_CAMERA_AUTHOR) {
             this.checkDeviceCameraAuthorizationStatus();
           }
+          if (command === Constants.MOCK_ONERROR) {
+            this.mockOnError();
+          }
         });
     }
   }
@@ -275,6 +279,13 @@ export struct RTNCameraKitView {
   async checkDeviceCameraAuthorizationStatus() {
     const result = CameraManager.checkDeviceCameraAuthorizationStatus()
     this.ctx.rnInstance.emitDeviceEvent('checkDeviceCameraAuthorizationStatus', result);
+  }
+
+  /**
+   * 模拟onError回调
+   */
+  mockOnError() {
+    this.isMockOnError = true;
   }
 
   /*
@@ -299,10 +310,17 @@ export struct RTNCameraKitView {
   }
 
   private updateProps(props: CameraProps) {
+    console.error("updateProps "+props.focusMode)
     this.isScan = props.scanBarcode;
     this.setDisplay();
     if (!this.isInitSuccess) {
       return;
+    }
+    //锁定模式居中显示黄色焦点框
+    if(props.focusMode == FocusMode.FOCUS_MODE_LOCKED) {
+       this.focusPointBol = true;
+       this.focusPointVal[0] = this.cameraWidth/2;
+       this.focusPointVal[1] = this.cameraHeight/2;
     }
     if (this.isScan) {
       ScanService.initProps(props);
@@ -431,7 +449,8 @@ export struct RTNCameraKitView {
       focusFrameDisplayDuration: this.currentProps.resetFocusTimeout ?? 5000,
       isScan: this.isScan,
       cameraOffsetX: this.cameraOffsetX,
-      cameraOffsetY: this.cameraOffsetY
+      cameraOffsetY: this.cameraOffsetY,
+      isMockOnError: this.isMockOnError
     })
   }
 

--- a/harmony/camera_kit/src/main/ets/common/Constants.ts
+++ b/harmony/camera_kit/src/main/ets/common/Constants.ts
@@ -32,6 +32,7 @@ export class Constants {
   static readonly TACK_PHOTO: string = 'takePhoto';
   static readonly REQUEST_DEVICE_CAMERA_AUTHOR: string = 'requestDeviceCameraAuthorization';
   static readonly CHECK_DEVICE_CAMERA_AUTHOR: string = 'checkDeviceCameraAuthorizationStatus';
+  static readonly MOCK_ONERROR: string = 'mockOnError';
   /**
    * The full percentage of component.
    */

--- a/harmony/camera_kit/src/main/ets/component/FocusAreaComponent.ets
+++ b/harmony/camera_kit/src/main/ets/component/FocusAreaComponent.ets
@@ -25,6 +25,7 @@ export struct FocusAreaComponent {
   @Prop focusFrameDisplayDuration: number = 5000;
   @Prop cameraOffsetX: number;
   @Prop cameraOffsetY: number;
+  @Prop isMockOnError: boolean = false;
 
   build() {
     Row() {
@@ -41,6 +42,11 @@ export struct FocusAreaComponent {
         const point: scanBarcode.Point | camera.Point =
           { x: e.touches[0].y / this.xComponentHeight, y: 1 - (e.touches[0].x / this.xComponentWidth) };
         if (this.isScan) {
+          if(this.isMockOnError) {
+             //用于模拟onError回调
+             ScanService.setFocusPointFn(null)
+             return;
+          }
           ScanService.setFocusPointFn(point)
         } else {
           CameraService.setFocusPoint(point);

--- a/harmony/camera_kit/src/main/ets/service/ScanService.ts
+++ b/harmony/camera_kit/src/main/ets/service/ScanService.ts
@@ -158,9 +158,15 @@ class ScanService {
 
   // 设置变焦比
   setZoomFn(zoomValue: number) {
-    const currentZoom = customScan.getZoom();
-    if (currentZoom === zoomValue) {
-      return;
+    try {
+      const currentZoom = customScan.getZoom();
+      if (currentZoom === zoomValue) {
+        return;
+      }
+    } catch (e) {
+      // Error message:Internal error. This interface cannot be used after the camera session is paused.
+      Logger.error(TAG, `This interface cannot be used after the camera session is paused`);
+      this.onError('This interface cannot be used after the camera session is paused');
     }
     if (this.zoomMode === 'off') {
       return;

--- a/src/Camera.tsx
+++ b/src/Camera.tsx
@@ -74,6 +74,14 @@ const Camera = React.forwardRef<CameraApi, CameraProps>((props, ref) => {
     });
   };
 
+
+  const mockOnError = ():Promise<void> => {
+       return new Promise(resolve => {
+      if (!nativeRef.current) throw new Error('nativeRef.current is NaN');
+      CameraCommands.mockOnError(nativeRef.current);
+    });
+  };
+
   DeviceEventEmitter.addListener('onZoom', (zoom: OnZoom) => {
     onZoom?.(zoom);
   });
@@ -109,6 +117,7 @@ const Camera = React.forwardRef<CameraApi, CameraProps>((props, ref) => {
     capture,
     requestDeviceCameraAuthorization,
     checkDeviceCameraAuthorizationStatus,
+    mockOnError
   }));
 
   return (

--- a/src/CameraKitNativeComponent.ts
+++ b/src/CameraKitNativeComponent.ts
@@ -86,6 +86,7 @@ export enum FocusMode {
 }
 
 export interface NativeCameraProps extends ViewProps {
+  focusMode?: WithDefault<0 | 1 | 2 | 3 ,0>;
   flashMode?: WithDefault<0 | 1 | 2 | 3 ,0>;
   zoomMode?: WithDefault<'on' | 'off','on'>;
   torchMode?: WithDefault<'on' | 'off' ,'off'>;
@@ -139,12 +140,14 @@ export interface VisionCameraCommandsType {
   takePhoto: (viewRef: React.ElementRef<CameraComponentType>,) => Promise<any>;
   requestDeviceCameraAuthorization: (viewRef: React.ElementRef<CameraComponentType>,) => Promise<boolean>;
   checkDeviceCameraAuthorizationStatus: (viewRef: React.ElementRef<CameraComponentType>,) => Promise<boolean>;
+  mockOnError: (viewRef: React.ElementRef<CameraComponentType>,) => Promise<boolean>;
 }
 
 export const CameraCommands: VisionCameraCommandsType = codegenNativeCommands<VisionCameraCommandsType>({
   supportedCommands: [
     'takePhoto',
     'requestDeviceCameraAuthorization',
-    'checkDeviceCameraAuthorizationStatus'
+    'checkDeviceCameraAuthorizationStatus',
+    'mockOnError'
   ],
 });

--- a/types/types.ts
+++ b/types/types.ts
@@ -50,6 +50,7 @@ export type CameraApi = {
   capture: () => Promise<CaptureData>;
   requestDeviceCameraAuthorization: () => Promise<boolean>;
   checkDeviceCameraAuthorizationStatus: () => Promise<boolean>;
+  mockOnError: () => void;
 };
  
 export enum FlashMode {


### PR DESCRIPTION
# Summary

- fix:修复锁定模式没有显示黄色焦点框以及添加支持模拟onError回调
- Close: #39 


## Test Plan

-  测试用例focusMode选择锁定，黄色焦点框显示
- 测试用例scanOnError缩放相机，触发onError回调信息
- 已验证ok

## Checklist

<!-- 检查项, 请自行排查并打钩, 通过: [X] -->

- [X] 已经在真机设备或模拟器上测试通过
- [ ] 已经与 Android 或 iOS 平台做过效果/功能对比
- [ ] 已经添加了对应 API 的测试用例（如需要）
- [ ] 已经更新了文档（如需要）
- [ ] 更新了 JS/TS 代码 (如有)

<!-- Check completed item, when applicable, via: [X] -->

- [ ] I have tested this on a device and a simulator
- [ ] I have already compared the effects/features with the Android or iOS platforms
- [ ] I added a test for the API (if applicable)
- [ ] I have updated the JS/TS (if applicable)
- [ ] I updated the documentation (if applicable)
